### PR TITLE
fix: move_for node name

### DIFF
--- a/bin/move_for.cpp
+++ b/bin/move_for.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
 
   rclcpp::init(argc, argv);
 
-  auto node = std::make_shared<rclcpp::Node>("maneuver_until");
+  auto node = std::make_shared<rclcpp::Node>("move_for");
 
   auto maneuver_consumer = std::make_shared<tosshin_cpp::ManeuverConsumer>(node);
 


### PR DESCRIPTION
Fix node name from `maneuver_until` into `move_for`.